### PR TITLE
wooteco precourse js-onboarding solving 1~4

### DIFF
--- a/woowacourse-precourse/javascript-onboarding/week1/PROBLEM1/김민준.js
+++ b/woowacourse-precourse/javascript-onboarding/week1/PROBLEM1/김민준.js
@@ -27,34 +27,13 @@ function getPageEachDigitMultiply(page) {
 }
 
 /**
- * 받은 페이지들이 룰에 어긋나지 않고 유효한 쌍인지 확인하는 함수
- *
- * @param {number[]} pobi pobi의 왼쪽, 오른쪽 페이지
- * @param {number[]} crong crong의 왼쪽, 오른쪽 페이지
- * @returns {boolean}
+ * pobi와 crong의 왼쪽 오른쪽 페이지 쌍을 받아 각각의 최대 점수를 return 하는 함수
+ * 
+ * @param {number[]} pobi pobi의 [왼쪽, 오른쪽] 페이지
+ * @param {number[]} crong crong의 [왼쪽, 오른쪽] 페이지
+ * @returns 
  */
-function isValidPage(pobi, crong) {
-  const PAGE_LIST = [...pobi, ...crong];
-  // 시작 면이나 마지막 면이 나올 경우
-  if (PAGE_LIST.includes(1) || PAGE_LIST.includes(400)) return false;
-
-  // 왼쪽과 오른쪽 페이지 쌍이 옳지 않을 경우
-  if (pobi[0] + 1 !== pobi[1]) return false;
-  if (crong[0] + 1 !== crong[1]) return false;
-
-  return true;
-}
-
-function solution() {
-  let pobi = [97, 98];
-  let crong = [197, 198];
-  // let pobi = [131, 132];
-  // let crong = [211, 212];
-  // let pobi = [99, 102];
-  // let crong = [211, 212];
-
-  if (isValidPage(pobi, crong) === false) return -1;
-
+function getMaxScore(pobi, crong) {
   const [POBI_LEFT_PAGE, POBI_RIGHT_PAGE] = pobi;
   const [CRONG_LEFT_PAGE, CRONG_RIGHT_PAGE] = crong;
 
@@ -84,12 +63,45 @@ function solution() {
     CRONG_RIGHT_PAGE_MAX_SCORE
   );
 
+  return { POBI_MAX_SCORE, CRONG_MAX_SCORE };
+}
+
+/**
+ * 받은 페이지들이 룰에 어긋나지 않고 유효한 쌍인지 확인하는 함수
+ *
+ * @param {number[]} pobi pobi의 왼쪽, 오른쪽 페이지
+ * @param {number[]} crong crong의 왼쪽, 오른쪽 페이지
+ * @returns {boolean}
+ */
+function isValidPage(pobi, crong) {
+  const PAGE_LIST = [...pobi, ...crong];
+  // 시작 면이나 마지막 면이 나올 경우
+  if (PAGE_LIST.includes(1) || PAGE_LIST.includes(400)) return false;
+
+  // 왼쪽과 오른쪽 페이지 쌍이 옳지 않을 경우
+  if (pobi[0] + 1 !== pobi[1]) return false;
+  if (crong[0] + 1 !== crong[1]) return false;
+
+  return true;
+}
+
+function solution() {
+  let pobi = [97, 98];
+  let crong = [197, 198];
+  // let pobi = [131, 132];
+  // let crong = [211, 212];
+  // let pobi = [99, 102];
+  // let crong = [211, 212];
+
+  if (isValidPage(pobi, crong) === false) return -1;
+
   let result = 0;
   const gameResultObj = {
     POBI_WIN: 1,
     CRONG_WIN: 2,
     DRAW: 0,
   };
+  const { POBI_MAX_SCORE, CRONG_MAX_SCORE } = getMaxScore(pobi, crong);
 
   if (POBI_MAX_SCORE > CRONG_MAX_SCORE) result = gameResultObj.POBI_WIN;
   else if (POBI_MAX_SCORE < CRONG_MAX_SCORE) result = gameResultObj.CRONG_WIN;

--- a/woowacourse-precourse/javascript-onboarding/week1/PROBLEM1/김민준.js
+++ b/woowacourse-precourse/javascript-onboarding/week1/PROBLEM1/김민준.js
@@ -1,0 +1,102 @@
+/**
+ * 한 페이지 숫자를 받아 각각의 자릿수를 더한 값을 return 하는 함수
+ *
+ * @param {number} page 페이지 숫자
+ * @returns {number}
+ */
+function getPageEachDigitSum(page) {
+  return page
+    .toString()
+    .split('')
+    .map(Number)
+    .reduce((acc, cur) => acc + cur);
+}
+
+/**
+ * 한 페이지 숫자를 받아 각각의 자릿수를 곱한 값을 return 하는 함수
+ *
+ * @param {number} page 페이지 숫자
+ * @returns {number}
+ */
+function getPageEachDigitMultiply(page) {
+  return page
+    .toString()
+    .split('')
+    .map(Number)
+    .reduce((acc, cur) => acc * cur);
+}
+
+/**
+ * 받은 페이지들이 룰에 어긋나지 않고 유효한 쌍인지 확인하는 함수
+ *
+ * @param {number[]} pobi pobi의 왼쪽, 오른쪽 페이지
+ * @param {number[]} crong crong의 왼쪽, 오른쪽 페이지
+ * @returns {boolean}
+ */
+function isValidPage(pobi, crong) {
+  const PAGE_LIST = [...pobi, ...crong];
+  // 시작 면이나 마지막 면이 나올 경우
+  if (PAGE_LIST.includes(0) || PAGE_LIST.includes(400)) return false;
+
+  // 왼쪽과 오른쪽 페이지 쌍이 옳지 않을 경우
+  if (pobi[0] + 1 !== pobi[1]) return false;
+  if (crong[0] + 1 !== crong[1]) return false;
+
+  return true;
+}
+
+function solution() {
+  let pobi = [97, 98];
+  let crong = [197, 198];
+  // let pobi = [131, 132];
+  // let crong = [211, 212];
+  // let pobi = [99, 102];
+  // let crong = [211, 212];
+
+  if (isValidPage(pobi, crong) === false) return -1;
+
+  const [POBI_LEFT_PAGE, POBI_RIGHT_PAGE] = pobi;
+  const [CRONG_LEFT_PAGE, CRONG_RIGHT_PAGE] = crong;
+
+  const POBI_LEFT_PAGE_MAX_SCORE = Math.max(
+    getPageEachDigitMultiply(POBI_LEFT_PAGE),
+    getPageEachDigitSum(POBI_LEFT_PAGE)
+  );
+  const POBI_RIGHT_PAGE_MAX_SCORE = Math.max(
+    getPageEachDigitMultiply(POBI_RIGHT_PAGE),
+    getPageEachDigitSum(POBI_RIGHT_PAGE)
+  );
+  const CRONG_LEFT_PAGE_MAX_SCORE = Math.max(
+    getPageEachDigitMultiply(CRONG_LEFT_PAGE),
+    getPageEachDigitSum(CRONG_LEFT_PAGE)
+  );
+  const CRONG_RIGHT_PAGE_MAX_SCORE = Math.max(
+    getPageEachDigitMultiply(CRONG_RIGHT_PAGE),
+    getPageEachDigitSum(CRONG_RIGHT_PAGE)
+  );
+
+  const POBI_MAX_SCORE = Math.max(
+    POBI_LEFT_PAGE_MAX_SCORE,
+    POBI_RIGHT_PAGE_MAX_SCORE
+  );
+  const CRONG_MAX_SCORE = Math.max(
+    CRONG_LEFT_PAGE_MAX_SCORE,
+    CRONG_RIGHT_PAGE_MAX_SCORE
+  );
+
+  let result = 0;
+  const gameResultObj = {
+    POBI_WIN: 1,
+    CRONG_WIN: 2,
+    DRAW: 0,
+  };
+
+  if (POBI_MAX_SCORE > CRONG_MAX_SCORE) result = gameResultObj.POBI_WIN;
+  else if (POBI_MAX_SCORE < CRONG_MAX_SCORE) result = gameResultObj.CRONG_WIN;
+  else result = gameResultObj.DRAW;
+
+  return result;
+}
+
+const RESULT = solution();
+console.log(RESULT);

--- a/woowacourse-precourse/javascript-onboarding/week1/PROBLEM1/김민준.js
+++ b/woowacourse-precourse/javascript-onboarding/week1/PROBLEM1/김민준.js
@@ -31,7 +31,7 @@ function getPageEachDigitMultiply(page) {
  * 
  * @param {number[]} pobi pobi의 [왼쪽, 오른쪽] 페이지
  * @param {number[]} crong crong의 [왼쪽, 오른쪽] 페이지
- * @returns 
+ * @returns {number[]} pobi와 crong의 최대 점수 return
  */
 function getMaxScore(pobi, crong) {
   const [POBI_LEFT_PAGE, POBI_RIGHT_PAGE] = pobi;
@@ -63,7 +63,7 @@ function getMaxScore(pobi, crong) {
     CRONG_RIGHT_PAGE_MAX_SCORE
   );
 
-  return { POBI_MAX_SCORE, CRONG_MAX_SCORE };
+  return [POBI_MAX_SCORE, CRONG_MAX_SCORE];
 }
 
 /**
@@ -101,7 +101,7 @@ function solution() {
     CRONG_WIN: 2,
     DRAW: 0,
   };
-  const { POBI_MAX_SCORE, CRONG_MAX_SCORE } = getMaxScore(pobi, crong);
+  const [POBI_MAX_SCORE, CRONG_MAX_SCORE] = getMaxScore(pobi, crong);
 
   if (POBI_MAX_SCORE > CRONG_MAX_SCORE) result = gameResultObj.POBI_WIN;
   else if (POBI_MAX_SCORE < CRONG_MAX_SCORE) result = gameResultObj.CRONG_WIN;

--- a/woowacourse-precourse/javascript-onboarding/week1/PROBLEM1/김민준.js
+++ b/woowacourse-precourse/javascript-onboarding/week1/PROBLEM1/김민준.js
@@ -36,7 +36,7 @@ function getPageEachDigitMultiply(page) {
 function isValidPage(pobi, crong) {
   const PAGE_LIST = [...pobi, ...crong];
   // 시작 면이나 마지막 면이 나올 경우
-  if (PAGE_LIST.includes(0) || PAGE_LIST.includes(400)) return false;
+  if (PAGE_LIST.includes(1) || PAGE_LIST.includes(400)) return false;
 
   // 왼쪽과 오른쪽 페이지 쌍이 옳지 않을 경우
   if (pobi[0] + 1 !== pobi[1]) return false;

--- a/woowacourse-precourse/javascript-onboarding/week1/PROBLEM2/김민준.js
+++ b/woowacourse-precourse/javascript-onboarding/week1/PROBLEM2/김민준.js
@@ -1,0 +1,29 @@
+function solution() {
+  const CRYPTOGRAM = 'browoanoommnaon';
+
+  let preStackSize = 0;
+  const recursion = (CRYPTOGRAM) => {
+    let stack = [];
+    CRYPTOGRAM.split('').map(el => {
+      // 스택의 top과 같으면 stack에서 pop
+      if(el === stack.at(-1)) stack.pop();
+      // 아니라면 push
+      else stack.push(el);
+    });
+
+    // 만약 이전 단계의 재귀의 스택의 사이즈와 같은 사이즈라면
+    // 중복되어서 사라진것이 없다는 뜻이므로
+    // return 해서 재귀 종료
+    if(stack.length === size) return stack.join('');
+    preStackSize = stack.length;
+
+    // 중복 제거한 stack으로 다시 재귀
+    return recursion(stack.join(''));
+  }
+
+  const RESULT = `"${recursion(CRYPTOGRAM)}"`;
+  return RESULT;
+}
+
+const RESULT = solution();
+console.log(RESULT);

--- a/woowacourse-precourse/javascript-onboarding/week1/PROBLEM2/김민준.js
+++ b/woowacourse-precourse/javascript-onboarding/week1/PROBLEM2/김민준.js
@@ -4,17 +4,18 @@ function solution() {
   let preStackSize = 0;
   const recursion = (CRYPTOGRAM) => {
     let stack = [];
-    CRYPTOGRAM.split('').map(el => {
-      // 스택의 top과 같으면 stack에서 pop
-      if(el === stack.at(-1)) stack.pop();
-      // 아니라면 push
-      else stack.push(el);
+    let preLetter = '';
+    let nextLetter = '';
+    CRYPTOGRAM.split('').forEach((el, idx) => {
+      nextLetter = CRYPTOGRAM[idx + 1];
+      if(el !== preLetter && el !== nextLetter) stack.push(el); 
+      preLetter = el;
     });
 
     // 만약 이전 단계의 재귀의 스택의 사이즈와 같은 사이즈라면
     // 중복되어서 사라진것이 없다는 뜻이므로
     // return 해서 재귀 종료
-    if(stack.length === size) return stack.join('');
+    if(stack.length === preStackSize) return stack.join('');
     preStackSize = stack.length;
 
     // 중복 제거한 stack으로 다시 재귀

--- a/woowacourse-precourse/javascript-onboarding/week1/PROBLEM3/김민준.js
+++ b/woowacourse-precourse/javascript-onboarding/week1/PROBLEM3/김민준.js
@@ -1,0 +1,18 @@
+function solution() {
+  const NUMBER = 13; // 4
+  // const NUMBER = 33; // 14
+  let numberListString = '';
+
+  for (let i = 1; i <= NUMBER; i += 1) {
+    numberListString += String(i);
+  }
+
+  const RESULT = numberListString
+    .split('')
+    .filter((el) => el == 3 || el == 6 || el == 9).length;
+
+  return RESULT;
+}
+
+const RESULT = solution();
+console.log(RESULT);

--- a/woowacourse-precourse/javascript-onboarding/week1/PROBLEM3/김민준.js
+++ b/woowacourse-precourse/javascript-onboarding/week1/PROBLEM3/김민준.js
@@ -9,7 +9,8 @@ function solution() {
 
   const RESULT = numberListString
     .split('')
-    .filter((el) => el == 3 || el == 6 || el == 9).length;
+    .map(Number)
+    .filter((el) => el === 3 || el === 6 || el === 9).length;
 
   return RESULT;
 }

--- a/woowacourse-precourse/javascript-onboarding/week1/PROBLEM4/김민준.js
+++ b/woowacourse-precourse/javascript-onboarding/week1/PROBLEM4/김민준.js
@@ -1,0 +1,23 @@
+function solution() {
+  const WORD = "I love you"; // "R olev blf"
+  const LOWER_ALPHABET = 'abcdefghijklmnopqrstuvwxyz';
+  const UPPER_ALPHABET = LOWER_ALPHABET.toUpperCase();
+
+  let result = '';
+  WORD.split('').map((el) => {
+    if(LOWER_ALPHABET.includes(el)) {
+      let index = LOWER_ALPHABET.indexOf(el) * -1 - 1;
+      result += LOWER_ALPHABET.at(index);
+    }
+    else if(UPPER_ALPHABET.includes(el)) {
+      let index = UPPER_ALPHABET.indexOf(el) * -1 - 1;
+      result += UPPER_ALPHABET.at(index);
+    }
+    else result += el;
+  });
+
+  return result;
+}
+
+const RESULT = solution();
+console.log(RESULT);


### PR DESCRIPTION
### 1번
- 페이지의 숫자의 각 자리의 합을 구하는 함수 getPageEachDigitSum() 구현
- 페이지의 숫자의 각 자리의 곱을 구하는 함수 getPageEachDigitMultiply() 구현
- pobi와 crong이 가질 수 있는 최대 점수를 구하는 함수 getMaxScore() 구현
- 입력으로 들어온 페이지가 유효한 페이지인지 검사하는 isValidPage() 구현
  * 0이나 400, 즉 첫번째나 마지막 페이지를 펼쳤을 경우 false return
  * pobi와 crong이 펼친 페이지가 왼쪽 오른쪽 쌍이 맞지 않을 경우 false return
  * 그 외 true return (더 생각해야 할 조건이 있다면 comment 달아주세요)
- pobi와 crong의 최댓값 비교후 return
---
### 2번
- 스택을 이용한 재귀로 구현
- ~~반복문을 돌면서 하나씩 스택에 넣어주고, 만약 현재의 element와 스택의 top이 같다면 stack.pop()~~
- ~~그 외에는 push~~
- 반복문을 돌면서 현재의 index를 idx라고 한다면, idx-1과 idx+1의 문자를 비교해서 다 다르다면 stack에 push
- 위 비교가 끝난 후 idx-1의 문자를 저장하는 변수 preLetter에 현재 문자 저장
- 위 과정을 마친 후
  * 전 단계의 재귀의 스택의 사이즈와 현재 스택의 사이즈가 같다면 삭제된 것이 없다는 뜻이므로 바로 return
  * 전 단계의 재귀의 스택의 사이즈와 현재 스택의 사이즈가 다르다면 다음 단계 재귀 실행
- 재귀 모두 마친 후 결과값 return
---
### 3번
- 1부터 input 값 까지의 모든 숫자 string으로 만든 후 이어 붙여줌
- filter()를 통해 3,6,9가 있는 것만 걸러낸 배열의 길이 return
---
### 4번
- 소문자를 다 나열한 문자열과 대문자를 다 나열한 문자열을 각각 만들어줌
- word를 반복문으로 돌면서 알파벳이라면 그 알파벳이 소문자인지 대문자인지 판별 후 반대 인덱스 값을 result에 붙여줌
- 알파벳이 아니라면 그대로 result에 붙여줌
- 결과값 return