### PR TITLE
wooteco precourse js-onboarding solving 5~7

### DIFF
--- a/woowacourse-precourse/javascript-onboarding/week1/PROBLEM5/김민준.js
+++ b/woowacourse-precourse/javascript-onboarding/week1/PROBLEM5/김민준.js
@@ -1,0 +1,15 @@
+function solution() {
+  let money = 50237;
+  // let money = 15000;
+  let moneyTypeList = [50000, 10000, 5000, 1000, 500, 100, 50, 10, 1];
+  let result = Array.from({ length: moneyTypeList.length }, () => 0);
+
+  moneyTypeList.forEach((el, idx) => {
+    result[idx] = Math.floor(money / el);
+    money %= el;
+  });
+
+  console.log(result);
+}
+
+solution();

--- a/woowacourse-precourse/javascript-onboarding/week1/PROBLEM6/김민준.js
+++ b/woowacourse-precourse/javascript-onboarding/week1/PROBLEM6/김민준.js
@@ -21,15 +21,13 @@ function solution() {
       if (idx < NICKNAME.length - 1) {
         // 연속된 2글자 구하기
         const SUB_NICKNAME = NICKNAME.slice(idx, idx + 2);
-        // 
         const PARENT_NICKNAME = SUB_NICKNAME_OBJ[SUB_NICKNAME];
         // 객체에 이미 SUB_NICKNAME의 부모 NICKNAME이 있고,
-        // 그 부모 NICKNAME이 현재 NICKNAME이 아닐경우 
+        // 그 부모 NICKNAME이 현재 NICKNAME이 아닐경우
         if (PARENT_NICKNAME && PARENT_NICKNAME !== NICKNAME) {
           result.push(EMAIL);
           result.push(USER_EMAIL_OBJ[PARENT_NICKNAME]);
-        }
-        else SUB_NICKNAME_OBJ[SUB_NICKNAME] = NICKNAME;
+        } else SUB_NICKNAME_OBJ[SUB_NICKNAME] = NICKNAME;
       }
     });
   });

--- a/woowacourse-precourse/javascript-onboarding/week1/PROBLEM6/김민준.js
+++ b/woowacourse-precourse/javascript-onboarding/week1/PROBLEM6/김민준.js
@@ -1,0 +1,40 @@
+function solution() {
+  const FORMS = [
+    ['jm@email.com', '제이엠'],
+    ['jason@email.com', '제이슨'],
+    ['woniee@email.com', '워니'],
+    ['mj@email.com', '엠제이'],
+    ['nowm@email.com', '이제엠'],
+  ];
+
+  // key를 NICKNAME으로 가지고, value를 EMAIL로 가지는 객체 생성
+  const USER_EMAIL_OBJ = {};
+  const SUB_NICKNAME_OBJ = {};
+  let result = [];
+
+  FORMS.forEach((FORM) => {
+    // FORM의 정보를 EMAIL과 NICKNAME으로 분리
+    const [EMAIL, NICKNAME] = FORM;
+    USER_EMAIL_OBJ[NICKNAME] = EMAIL;
+
+    NICKNAME.split('').forEach((_, idx) => {
+      if (idx < NICKNAME.length - 1) {
+        // 연속된 2글자 구하기
+        const SUB_NICKNAME = NICKNAME.slice(idx, idx + 2);
+        // 
+        const PARENT_NICKNAME = SUB_NICKNAME_OBJ[SUB_NICKNAME];
+        // 객체에 이미 SUB_NICKNAME의 부모 NICKNAME이 있고,
+        // 그 부모 NICKNAME이 현재 NICKNAME이 아닐경우 
+        if (PARENT_NICKNAME && PARENT_NICKNAME !== NICKNAME) {
+          result.push(EMAIL);
+          result.push(USER_EMAIL_OBJ[PARENT_NICKNAME]);
+        }
+        else SUB_NICKNAME_OBJ[SUB_NICKNAME] = NICKNAME;
+      }
+    });
+  });
+
+  console.log([...new Set(result)].sort());
+}
+
+solution();

--- a/woowacourse-precourse/javascript-onboarding/week1/PROBLEM7/김민준.js
+++ b/woowacourse-precourse/javascript-onboarding/week1/PROBLEM7/김민준.js
@@ -1,0 +1,75 @@
+function solution() {
+  const USER = 'mrko';
+  const FRIENDS = [
+    ['donut', 'jun'],
+    ['donut', 'andole'],
+    ['donut', 'mrko'],
+    ['shakevan', 'andole'],
+    ['shakevan', 'jun'],
+    ['shakevan', 'mrko'],
+  ];
+  const VISITORS = ['bedi', 'bedi', 'donut', 'bedi', 'shakevan'];
+
+  // name을 key값으로 가지고, name과 친구인 list를 value로 가지는 object
+  let relationObj = {};
+  // score수를 저장하는 object
+  let scoreObj = {};
+
+  const ALL_USER = new Set(FRIENDS.flat());
+  ALL_USER.add(...VISITORS);
+  [...ALL_USER].forEach((USER) => {
+    // USER에 대한 친구 list를 빈 배열로 초기화
+    relationObj[USER] = [];
+    // USER에 대한 점수 0으로 초기화
+    scoreObj[USER] = 0;
+  });
+
+  FRIENDS.forEach((FRIEND) => {
+    const [USER1, USER2] = FRIEND;
+
+    relationObj[USER1].push(USER2);
+    relationObj[USER2].push(USER1);
+  });
+
+  // 본인의 점수는 셀 필요 없기 때문에 object에서 delete
+  delete scoreObj[USER];
+  relationObj[USER].forEach((ALREADY_FREIND) => {
+    // 이미 친구인 USER는 delete
+    delete scoreObj[ALREADY_FREIND];
+  });
+
+  VISITORS.forEach((VISITOR) => {
+    // 만약 VISITOR가 scoreObj에 존재한다면 점수 + 1
+    // (이미 친구일 경우는 이미 삭제되서 object에 존재하지 않음)
+    if (VISITOR in scoreObj) scoreObj[VISITOR] += 1;
+  });
+
+  for (key in scoreObj) {
+    // 만약 같이 아는 USER면 중복되므로 제거됨
+    let knowTogether = new Set();
+    knowTogether.add(relationObj[USER]);
+    knowTogether.add(relationObj[key]);
+
+    // 중복 제거하지 말고 배열에 다 넣어줌
+    let tmp = [...relationObj[USER], ...relationObj[key]];
+
+    // 배열과 set의 사이즈의 차이가 중복된 수 이기 때문에
+    // 그 수에 10을 곱한수가 score
+    let score = (tmp.length - knowTogether.size) * 10;
+
+    scoreObj[key] += score;
+  }
+
+  let result = [];
+  result = Object.entries(scoreObj)
+    .sort() // 이름순으로 정렬
+    .sort((a, b) => b[1] - a[1]) // 점수순으로 정렬
+    .filter((el, idx) => { // 0이 아니고 상위 5개인것만 filtering
+      return el[1] !== 0 && idx < 5;
+    })
+    .map((el) => el[0]); // 이름만 출력
+
+  console.log(result);
+}
+
+solution();


### PR DESCRIPTION
### 5번
- 돈의 액수 종류들을 배열에 내림차순으로 초기화
- 배열을 반복문을 돌면서
  - 결과에 배열의 값(돈의 액수)으로 나눈 몫을 넣어주고,
  - input으로 들어온 money는 나머지만 남겨줌
---
### 6번
- { NICKNAME: EMAIL } 와 같은 (key, value) 쌍을 가지는 USER_EMAIL_OBJ 선언
- { SUB_NICKNAME: PARENT_NICKNAME } 와 같은 (key, value) 쌍을 가지는 SUB_NICKNAME_OBJ 선언
  - SUB_NICKNAME은 한 NICKNAME에서 2글자만 잘라낸 string
  - PARENT_NICKNAME은 SUB_NICKNAME이 파생된 부모 NICKNAME
- 만약 객체에 이미 SUB_NICKNAME이 존재한다면 전의 다른 NICKNAME에서 똑같이 파생된 SUB_NICKNAME 이라는 의미
  - 따라서 현재의 NICKNAME과 객체에 존재하는 그 SUB_NICKNAME의 PARENT_NICKNAME을 결과값에 넣어줌
- 존재하지 않는다면 현재 SUB_NICKNAME의 PARENT_NICKNAME을 현재 NICKNAME으로 설정
---
### 7번
- 모든 인원에 대해서 이름을 key로 가지고, 친구 리스트를 value로 가지는 object 생성
- 모든 인원에 대해서 점수를 value로 가지는 object 생성
  - 자신의 점수를 셀 필요는 없으니 자신은 delete
  - 이미 친구인 사람들의 점수를 셀 필요는 없으니 친구들은 delete
- 함께 친구인 친구수 * 10과 방문수를 더해서 score 계산
- score가 저장된 object를 entry로 받아서 이름순으로 정렬후, 점수순으로 정렬
- filter를 이용해 0인값과 index가 5이상인 것은 걸러줌