### PR TITLE
위장

### DIFF
--- a/programmers/level2/H-Index/김민준.js
+++ b/programmers/level2/H-Index/김민준.js
@@ -3,6 +3,8 @@ function solution(citations) {
   citations.sort((a, b) => a - b); // 오름차순으로 정렬
 
   for (let i = 0; i < n; i += 1) {
+    // 남은 인용 횟수들이 현재 인용 횟수 이상일 경우
+    // 이미 정렬을 했기 때문에 남은 갯수로 판단 가능
     const H_INDEX = n - i;
     if (citations[i] >= H_INDEX) return H_INDEX;
   }

--- a/programmers/level2/H-Index/김민준.js
+++ b/programmers/level2/H-Index/김민준.js
@@ -1,0 +1,11 @@
+function solution(citations) {
+  let n = citations.length;
+  citations.sort((a, b) => a - b); // 오름차순으로 정렬
+
+  for (let i = 0; i < n; i += 1) {
+    const H_INDEX = n - i;
+    if (citations[i] >= H_INDEX) return H_INDEX;
+  }
+
+  return 0;
+}

--- a/programmers/level2/위장/김민준.js
+++ b/programmers/level2/위장/김민준.js
@@ -1,0 +1,18 @@
+function solution(clothes) {
+  let answer = 1;
+  let clothKindObj = {};
+  
+  // 해당 옷을 입었을 경우 +1 을 해줌
+  // 해당 옷을 입지 않았을 경우를 default로 1로 설정
+  // 만약 headgear: 2 라면, 한 가지의 headgear와 headgear를 쓰지 않았을 경우로 총 2가 됨
+  for(const [_, KIND] of clothes) {
+      clothKindObj[KIND] = (clothKindObj[KIND] || 1) + 1;
+  }
+  
+  // 올 수 있는 경우의 수를 다 곱해서 구해줌
+  answer = Object.values(clothKindObj).reduce((acc, cur) => acc * cur, 1);
+  
+  // 곱하는 수에 착용하지 않는 경우의 수도 포함되어 있기 때문에,
+  // 모두 착용하지 않았을 경우의 수 1을 빼줌
+  return answer - 1;
+}


### PR DESCRIPTION
- 이름은 기억하지 않고 각 종류별 개수를 세어줌
- 착용하지 않는 경우도 고려해야 하기 때문에 총 종류별 개수 + 1, 즉 default가 0이 아니라 **착용하지 않는 경우까지 고려해서 default는 1로 설정**해줌
- 모든 경우의 수를 다 곱해서 조합의 개수를 구해주고,
- 각 종류의 개수마다 착용하지 않는 경우의 수도 들어가기 때문에 **모두 착용하지 않는 경우의 수는 고려하지 않아야 하므로 결과값에서 1을 빼줌**